### PR TITLE
サインアップ機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8763,6 +8763,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest": "^24.1.0",
     "jest-transform-stub": "^2.0.0",
     "lint-staged": "^8.2.1",
+    "lodash.clonedeep": "^4.5.0",
     "nodemon": "^1.18.9",
     "prettier": "^1.16.4",
     "vue-jest": "^4.0.0-0"

--- a/pages/signUp.vue
+++ b/pages/signUp.vue
@@ -65,9 +65,17 @@ export default {
         email: this.email,
         password: this.password
       }
-      this.$axios.$post('/signup', querystring.stringify(req)).then((res) => {
-        alert(res)
-      })
+      this.$axios
+        .$post('/signup', querystring.stringify(req))
+        .then((res) => {
+          alert(res.message)
+          if (res.message === '登録完了です') {
+            this.$router.push({ path: '/signin' })
+          }
+        })
+        .catch((error) => {
+          console.log(error.message)
+        })
     }
   }
 }

--- a/pages/signUp.vue
+++ b/pages/signUp.vue
@@ -3,34 +3,34 @@
     <div class="wrapper">
       <div class="login-form row">
         <div class="col-sm-12">
-          <form action="" method="post" name="Login_Form" class="form-signin">
+          <div class="form-signin">
             <h3 class="form-signin-heading">Sign Up</h3>
 
-            <label for="username">Username</label>
+            <label for="email">Email</label>
             <input
-              id="username"
-              type="text"
+              id="email"
+              v-model="email"
+              type="email"
               class="form-control"
-              name="Username"
-              placeholder="Username"
+              name="email"
+              placeholder="Email"
               required=""
               autofocus=""
             />
             <label for="password">password</label>
             <input
               id="password"
+              v-model="password"
               type="password"
               class="form-control"
-              name="Password"
+              name="password"
               placeholder="Password"
               required=""
             />
 
             <button
               class="btn btn-lg btn-outline-info btn-block"
-              name="Submit"
-              value="Login"
-              type="Submit"
+              @click="signup"
             >
               Sign Up
             </button>
@@ -42,7 +42,7 @@
                 Home
               </nuxt-link>
             </div>
-          </form>
+          </div>
         </div>
       </div>
     </div>
@@ -50,7 +50,27 @@
 </template>
 
 <script>
-export default {}
+import querystring from 'querystring'
+
+export default {
+  data() {
+    return {
+      email: '',
+      password: ''
+    }
+  },
+  methods: {
+    signup() {
+      const req = {
+        email: this.email,
+        password: this.password
+      }
+      this.$axios.$post('/signup', querystring.stringify(req)).then((res) => {
+        alert(res)
+      })
+    }
+  }
+}
 </script>
 
 <style scoped>

--- a/pages/signUp.vue
+++ b/pages/signUp.vue
@@ -30,7 +30,7 @@
 
             <button
               class="btn btn-lg btn-outline-info btn-block"
-              @click="signup"
+              @click="signUp"
             >
               Sign Up
             </button>
@@ -50,8 +50,6 @@
 </template>
 
 <script>
-import querystring from 'querystring'
-
 export default {
   data() {
     return {
@@ -60,22 +58,19 @@ export default {
     }
   },
   methods: {
-    signup() {
-      const req = {
+    // emailとpasswordでsignup処理
+    async signUp() {
+      const reqUserInfo = {
         email: this.email,
         password: this.password
       }
-      this.$axios
-        .$post('/signup', querystring.stringify(req))
-        .then((res) => {
-          alert(res.message)
-          if (res.message === '登録完了です') {
-            this.$router.push({ path: '/signin' })
-          }
-        })
-        .catch((error) => {
-          console.log(error.message)
-        })
+      // 入力されたデータをpost 成功でresult.userにuser情報が格納される
+      const res = await this.$store.dispatch('user/signUp', reqUserInfo)
+      alert(res.message)
+      // 登録完了ならsigninページに遷移
+      if (res.user) {
+        this.$router.push({ path: '/signin' })
+      }
     }
   }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,8 @@ const app = express()
 const bodyParser = require('body-parser')
 const session = require('express-session')
 const config = require('../nuxt.config.js')
+const signinRouter = require('./routes/signin')
+const signupRouter = require('./routes/signup')
 const passport = require('./passportAuth').passport
 
 app.use(bodyParser.urlencoded({ extended: false }))
@@ -20,8 +22,6 @@ app.use(passport.initialize())
 app.use(passport.session())
 
 // Import and Set Nuxt.js options
-const signinRouter = require('./routes/signin')
-
 config.dev = process.env.NODE_ENV !== 'production'
 
 async function start() {
@@ -38,6 +38,7 @@ async function start() {
     await nuxt.ready()
   }
   app.use('/signin', signinRouter)
+  app.use('/signup', signupRouter)
   // Give nuxt middleware to express
   app.use(nuxt.render)
 

--- a/server/controllers/signupController.js
+++ b/server/controllers/signupController.js
@@ -1,6 +1,7 @@
 const models = require('../models')
 
 const signupController = {
+  // emailとpasswordでsignup
   async signUp(req, res) {
     console.log(req.body)
     const email = req.body.email
@@ -13,7 +14,7 @@ const signupController = {
       })
     // emailが登録済みならフロントに返す
     if (user) {
-      return res.send('そのEmailは既に使われています')
+      return res.send({ message: 'そのEmailは既に使われています' })
     }
     // emailが使われていなければuser作成
     const createdUser = await models.user
@@ -25,7 +26,7 @@ const signupController = {
         res.status(404).send({ error: error.message })
       })
     console.log(createdUser)
-    res.sendStatus(200)
+    res.status(200).send({ message: '登録完了です' })
   }
 }
 module.exports = signupController

--- a/server/controllers/signupController.js
+++ b/server/controllers/signupController.js
@@ -26,7 +26,7 @@ const signupController = {
         res.status(404).send({ error: error.message })
       })
     console.log(createdUser)
-    res.status(200).send({ message: '登録完了です' })
+    res.status(200).send({ message: '登録完了です', user: createdUser })
   }
 }
 module.exports = signupController

--- a/server/controllers/signupController.js
+++ b/server/controllers/signupController.js
@@ -1,0 +1,31 @@
+const models = require('../models')
+
+const signupController = {
+  async signUp(req, res) {
+    console.log(req.body)
+    const email = req.body.email
+    const password = req.body.password
+    // emailに重複禁止設定をした為フィルターをかける
+    const user = await models.user
+      .findOne({ where: { email } })
+      .catch((error) => {
+        res.status(404).send({ error: error.message })
+      })
+    // emailが登録済みならフロントに返す
+    if (user) {
+      return res.send('そのEmailは既に使われています')
+    }
+    // emailが使われていなければuser作成
+    const createdUser = await models.user
+      .create({
+        email,
+        password
+      })
+      .catch((error) => {
+        res.status(404).send({ error: error.message })
+      })
+    console.log(createdUser)
+    res.sendStatus(200)
+  }
+}
+module.exports = signupController

--- a/server/migrations/20190930001733-create-user.js
+++ b/server/migrations/20190930001733-create-user.js
@@ -9,12 +9,10 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       email: {
-        allowNull: false,
         type: Sequelize.STRING,
         unique: true
       },
       password: {
-        allowNull: false,
         type: Sequelize.STRING
       },
       created_at: {

--- a/server/routes/signup.js
+++ b/server/routes/signup.js
@@ -1,0 +1,7 @@
+const express = require('express')
+const router = express.Router()
+const signupController = require('../controllers/signupController')
+
+router.post('/', signupController.signUp)
+
+module.exports = router

--- a/store/test/user.spec.js
+++ b/store/test/user.spec.js
@@ -1,0 +1,43 @@
+import Vuex, { Store } from 'vuex'
+import { createLocalVue } from '@vue/test-utils'
+import clonedeep from 'lodash.clonedeep'
+import axios from 'axios'
+import * as user from '@/store/user'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+let mockAxiosGetResult
+jest.mock('axios', () => ({
+  $post: jest.fn(() => Promise.resolve(mockAxiosGetResult))
+}))
+
+describe('store/user.js', () => {
+  let user1
+  let store
+  beforeEach(() => {
+    user1 = {
+      userId: 1,
+      email: 'test@test.com',
+      password: '123456'
+    }
+    store = new Store(clonedeep(user))
+  })
+  describe('actions', () => {
+    beforeEach(() => {
+      store.$axios = axios
+    })
+    describe('signUp', () => {
+      test('リクエストしたuser情報が格納されるか', async (done) => {
+        mockAxiosGetResult = {
+          userId: user1.userId,
+          email: user1.email,
+          password: user1.password
+        }
+        const res = await store.dispatch('signUp')
+        expect(res).toEqual(user1)
+        done()
+      })
+    })
+  })
+})

--- a/store/user.js
+++ b/store/user.js
@@ -1,0 +1,21 @@
+import querystring from 'querystring'
+
+export const state = () => ({})
+
+export const mutations = {}
+
+export const getters = {}
+
+export const actions = {
+  // signupのpost処理結果をフロントに返す
+  async signUp({ ctx }, reqUserInfo) {
+    console.log(reqUserInfo)
+    // signup処理の結果が格納される
+    const res = await this.$axios
+      .$post('/signup', querystring.stringify(reqUserInfo))
+      .catch((error) => {
+        console.log(error.message)
+      })
+    return res
+  }
+}


### PR DESCRIPTION
## 概要
emailとpasswordを使ってサインアップ機能の実装
DB設定でemailを`unique: true` の設定にした為、重複禁止になっています。
重複しているなら元のページのまま、登録成功したらサインインのページに遷移します。

サインイン機能は実装済みです。

## レビューしてほしいところ
・signupController.js 17行目
emailが重複していた場合、ステータスコードを400に設定しようと思ったのですが、
`res.status(400).send({message: 'そのemailは...'})`
と記述したところ、messageが送られずに400のエラーコードだけ送られてきました。

他に適切なステータスコードや記述法があるのか、または今のコードのように特にステータスコードはいらないのか、ご教授頂けると嬉しいです。

・store/user.js
テストしやすくする為にDB通信をaction経由にしましたが、登録した後のuser情報は特にstateに格納しなくても良いと思い記述しませんでした。
一般的にはどうなのでしょうか？
ユーザーが増える度にstateに格納されていくのもどうなのだろうと思いまして。。

・signup.vue 68行目` const res = ...`
この定数の名前がresで良いのかもやもやしています。
格納されるのはpostメソッドのresponseで、emailが重複していればmessageだけ、サインアップ成功すればuser情報とmessageが格納されるので、具体的な名前が付けづらかったです。
もし他に良い名前がありましたらお願いします。
